### PR TITLE
Allow meta-gems to be required

### DIFF
--- a/lib/pry-debundle.rb
+++ b/lib/pry-debundle.rb
@@ -43,12 +43,14 @@ class << Pry
       Gem.post_reset_hooks.reject!{ |hook| hook.source_location.first =~ %r{/bundler/} }
       Gem::Specification.reset
       load 'rubygems/custom_require.rb'
+      ::Kernel.class_eval { alias gem require }
       loaded = true
 
     # Rubygems 1.6 — TODO might be quite slow.
     elsif Gem.source_index && Gem.send(:class_variable_get, :@@source_index)
       Gem.source_index.refresh!
       load 'rubygems/custom_require.rb'
+      ::Kernel.class_eval { alias gem require }
       loaded = true
 
     else


### PR DESCRIPTION
The existing code doesn't restore the behavior of the "gem" method, which means that meta-gems like irbtools don't work even after running it. This fixes the problem, and it should allow you to use meta-gems in ~/.irbrc even when using bundler.
