### PR TITLE
Foolproof debundle

### DIFF
--- a/lib/pry-debundle.rb
+++ b/lib/pry-debundle.rb
@@ -41,6 +41,8 @@ class << Pry
 
     if rubygems_18_or_better?
       if Gem.post_reset_hooks.reject!{ |hook| hook.source_location.first =~ %r{/bundler/} }
+        Bundler.preserve_gem_path
+        Gem.clear_paths
         Gem::Specification.reset
         remove_bundler_monkeypatches
         loaded = true


### PR DESCRIPTION
Gem::Specification.reset is not enough, since it would pick up the same GEM_HOME which was set by bundler. So we need to restore it first, then clear gem paths (to pickup a change in ENV) and then continue with previous hack.
